### PR TITLE
Add Moonsquads to the List of Social Discord Servers

### DIFF
--- a/_links/Other/Social/Moonsquads.md
+++ b/_links/Other/Social/Moonsquads.md
@@ -1,0 +1,7 @@
+---
+layout: link
+title: "Moonsquads"
+link: https://discord.gg/0mWbGXUnFkOk17NA
+owner: "Crowes"
+tags: [Other,Social]
+---


### PR DESCRIPTION
Please add the server, "Moonsquads", under the catagory, "Social".

Moonsquads is a community, or a middle-man, for players world-wide to find other people to play with online and take part in new betas and the favorites of the past decade or so.